### PR TITLE
Fix prep when modules have dependencies

### DIFF
--- a/src/duct/core.clj
+++ b/src/duct/core.clj
@@ -94,8 +94,13 @@
               :applied   applied
               :remaining (keys modules)})))
 
+(defn- init-modules [config]
+  (-> config
+      (ig/init [:duct/module])
+      (ig/find-derived :duct/module)))
+
 (defn- apply-modules [config]
-  (loop [modules (into (sorted-map) (ig/init config [:duct/module]))
+  (loop [modules (into (sorted-map) (init-modules config))
          applied []
          config  config]
     (if (seq modules)

--- a/test/duct/core_test.clj
+++ b/test/duct/core_test.clj
@@ -66,7 +66,15 @@
             (str "Missing module requirements: "
                  ::mod2 " requires \\(" ::xx "\\), "
                  ::mod3 " requires \\(" ::x " " ::y "\\)"))
-           (core/prep config))))))
+           (core/prep config)))))
+
+  (testing "valid modules with dependencies"
+    (let [config {::mod1 {:x (ig/ref ::x)},
+                  ::mod2 {}
+                  ::mod3 {}
+                  ::xx 1}]
+      (is (= (core/prep config)
+             (merge config {::xx 1, ::y 2, ::z 3}))))))
 
 (deftest test-environment-keyword
   (let [m {::core/environment :development}]


### PR DESCRIPTION
The current `prep` throws a NPE when modules have dependencies.
The updated `prep` only applies modules that derive from `:duct/module`.