### PR TITLE
spike on treating include as a module

### DIFF
--- a/test/duct/config.edn
+++ b/test/duct/config.edn
@@ -1,2 +1,2 @@
-{:duct.core/include ["duct/included"]
- :duct.core-test/a {:x 1}}
+[{:duct.core/include #duct/include ["duct/included"]
+   :duct.core-test/a {:x 1}}]

--- a/test/duct/core_test.clj
+++ b/test/duct/core_test.clj
@@ -64,16 +64,19 @@
 (defmethod ig/init-key ::mod4 [_ {:keys [foo]}]
   {:req #{}, :fn (fn [cfg] (assoc cfg :duct.example/foo foo))})
 
-(deftest test-prep
+(deftest including
   (testing "includes"
-    (let [config {::core/include ["duct/config"]
-                  ::b {:x 2}
-                  ::c {:x 3}}]
+    (let [config [{::core/include (core/include ["duct/config"])
+                   ::b {:x 2}
+                   ::c {:x 3}}]]
       (is (= (core/prep config)
              {::core/include ["duct/included" "duct/config"]
               ::a {:x 1}
               ::b {:x 2, :y 2}
-              ::c {:x 3}}))))
+              ::c {:x 3}})))))
+
+(deftest test-prep
+  
 
   (testing "include with custom reader"
     (let [config {::core/include ["duct/reader"]}]

--- a/test/duct/included.edn
+++ b/test/duct/included.edn
@@ -1,1 +1,1 @@
-{:duct.core-test/b {:y 2}}
+[{:duct.core-test/b {:y 2}}]


### PR DESCRIPTION
This is a rough pass at rewriting include so that it's a module.

One major, breaking change is that it requires config.edn files to contain vectors instead of maps. That allows the includes to be loaded before the rest of the config, without having to treat `:duct.core/include` as a special key.