### PR TITLE
Fix default value for Boolean env

### DIFF
--- a/src/duct/core/env.clj
+++ b/src/duct/core/env.clj
@@ -22,6 +22,9 @@
                          "\"yes\", \"y\", \"no\", \"n\", \"\" or nil.")
                     {:value x, :coercion 'Bool}))))
 
+(def ^:dynamic *env*
+  (into {} (System/getenv)))
+
 (defn env
   "Resolve an environment variable by name. Optionally accepts a type for
   coercion, and a keyword option, `:or`, that provides a default value if the
@@ -34,11 +37,12 @@
   ([name]
    (if (vector? name)
      (apply env name)
-     (System/getenv name)))
+     (*env* name)))
   ([name type & options]
    (if (keyword? type)
      (apply env name 'Str type options)
-     (let [{default :or} options]
-       (-> (System/getenv name)
-           (some-> (coerce type))
-           (or default))))))
+     (let [{default :or} options
+           value (*env* name)]
+       (if (nil? value)
+         default
+         (coerce value type))))))

--- a/test/duct/env_test.clj
+++ b/test/duct/env_test.clj
@@ -18,3 +18,23 @@
                (env/coerce "abc" 'Int)))
   (is (thrown? ExceptionInfo
                (env/coerce "tru" 'Bool))))
+
+(deftest env
+  (binding [env/*env* {"INTEGER"       "2000"
+                       "STRING"        "a string"
+                       "BOOLEAN_TRUE"  "true"
+                       "BOOLEAN_FALSE" "false"}]
+    (are [v expected] (= expected (env/env v))
+      '["UNDEFINED" Int]                nil
+      '["UNDEFINED" Int :or 3001]       3001
+      '["INTEGER" Int]                  2000
+      '["INTEGER" Int :or 3002]         2000
+      '["UNDEFINED" Bool]               nil
+      '["UNDEFINED" Bool :or true]      true
+      '["UNDEFINED" Bool :or false]     false
+      '["BOOLEAN_TRUE" Bool]            true
+      '["BOOLEAN_TRUE" Bool :or true]   true
+      '["BOOLEAN_TRUE" Bool :or false]  true
+      '["BOOLEAN_FALSE" Bool]           false
+      '["BOOLEAN_FALSE" Bool :or true]  false
+      '["BOOLEAN_FALSE" Bool :or false] false)))


### PR DESCRIPTION
This changes allows the use of `true` as default value for Boolean. It only use then default value when the env variable is `nil`.
I extracted the `System/getenv` to make it possible to test the function without setting a special environment. I don't know if there is a better way to do that.