### PR TITLE
Add Hawk dependency and auto reloading

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,8 @@
                  [medley "1.0.0"]
                  [fipp "0.6.14"]]
   :plugins [[lein-codox "0.10.3"]]
+  :profiles {:provided {:dependencies [[hawk "0.2.11"]
+                                       [integrant/repl "0.3.1"]]}}
   :codox {:output-path "codox"
           :project  {:name "Duct core"}
           :html     {:namespace-list :flat}

--- a/src/duct/core/repl.clj
+++ b/src/duct/core/repl.clj
@@ -1,7 +1,9 @@
 (ns duct.core.repl
   (:require [duct.core.resource :as resource]
             [fipp.ednize :as fipp]
-            [integrant.core :as ig]))
+            [integrant.core :as ig]
+            [integrant.repl :refer [reset]]
+            [hawk.core :as hawk]))
 
 (extend-type integrant.core.Ref
   fipp/IOverride
@@ -17,3 +19,19 @@
   fipp/IOverride
   fipp/IEdn
   (-edn [r] (tagged-literal 'duct/resource (:path r))))
+
+(defn- clojure-file? [_ {:keys [file]}]
+  (re-matches #"[^.].*(\.clj|\.edn)$" (.getName file)))
+
+(defn- auto-reset-handler [ctx event]
+  (binding [*ns* *ns*]
+    (integrant.repl/reset)
+    ctx))
+
+(defn auto-reset
+  "Automatically reset the system when a Clojure or edn file is changed in
+  `src` or `resources`."
+  []
+  (hawk/watch! [{:paths ["src/" "resources/" "dev/src/" "dev/resources/"]
+                 :filter clojure-file?
+                 :handler auto-reset-handler}]))


### PR DESCRIPTION
__NOTE:__ Moved from https://github.com/duct-framework/duct/pull/94 with additional changes.

## Problem
There is no way to auto reload your Duct project currently. See: https://github.com/duct-framework/core/issues/12

## Solution
As stated in https://github.com/duct-framework/core/issues/12 we can add [Hawk](https://github.com/wkf/hawk) as a dependency and write our own watcher.

## Usage:
``` Clojure
lein repl
(dev)
(auto-reset)
;; From here you can change any (Clojure / EDN) file 
;; in `src/` or `resources/` and the `(reset)` command 
;; will execute in a separate thread.
```

## Notes
* The auto-reset-handler was throwing an illegal state exception because of `*ns*`
```
;; java.lang.IllegalStateException: Can't change/establish root binding of: *ns* with set
```
I _fixed_ this by binding *ns* and then changing the namespace to `integrant.repl`. However I'd gladly accept a better solution
* Tested using Lein Checkouts. When running this through Emacs Cider the initial reload is slightly choppy, but afterwards I don't notice any interference. 