### PR TITLE
Add double coercion to #duct/env

### DIFF
--- a/src/duct/core/env.clj
+++ b/src/duct/core/env.clj
@@ -10,6 +10,9 @@
 (defmethod coerce 'Int [x _]
   (Long/parseLong x))
 
+(defmethod coerce 'Double [x _]
+  (Double/parseDouble x))
+
 (defmethod coerce 'Str [x _]
   (str x))
 

--- a/test/duct/env_test.clj
+++ b/test/duct/env_test.clj
@@ -5,22 +5,28 @@
 
 (deftest coerce
   (are [a b c] (= (env/coerce a b) c)
-    "a"    'Str  "a"
-    12     'Str  "12"
-    "123"  'Int  123
-    "true" 'Bool true
-    "TruE" 'Bool true
-    "t"    'Bool true
-    ""     'Bool false
-    "no"   'Bool false
-    nil    'Bool false)
+    "a"    'Str    "a"
+    12     'Str    "12"
+    "123"  'Int    123
+    "1.2"  'Double 1.2
+    "true" 'Bool   true
+    "TruE" 'Bool   true
+    "t"    'Bool   true
+    ""     'Bool   false
+    "no"   'Bool   false
+    nil    'Bool   false)
   (is (thrown? IllegalArgumentException
                (env/coerce "abc" 'Int)))
+  (is (thrown? NumberFormatException
+               (env/coerce "abc" 'Double)))
+  (is (thrown? NumberFormatException
+               (env/coerce "" 'Double)))
   (is (thrown? ExceptionInfo
                (env/coerce "tru" 'Bool))))
 
 (deftest env
   (binding [env/*env* {"INTEGER"       "2000"
+                       "DOUBLE"        "1.2"
                        "STRING"        "a string"
                        "BOOLEAN_TRUE"  "true"
                        "BOOLEAN_FALSE" "false"}]
@@ -29,6 +35,8 @@
       '["UNDEFINED" Int :or 3001]       3001
       '["INTEGER" Int]                  2000
       '["INTEGER" Int :or 3002]         2000
+      '["DOUBLE" Double]                1.2
+      '["DOUBLE" Double :or 1.3]        1.2
       '["UNDEFINED" Bool]               nil
       '["UNDEFINED" Bool :or true]      true
       '["UNDEFINED" Bool :or false]     false


### PR DESCRIPTION
We had a case where we wanted to feed double (not integer) via env vars. Seams like a reasonable thing to support in core, hence this PR.