### PR TITLE
Add an exception for when a module key isn't a function

### DIFF
--- a/src/duct/core.clj
+++ b/src/duct/core.clj
@@ -144,12 +144,21 @@
   ([source readers]
    (some->> source slurp (ig/read-string {:readers (merge-default-readers readers)}))))
 
+(defn- validate-module-function [k f]
+  (when-not (fn? f)
+    (throw (ex-info (str "Module with init-key " k " is not a function. Module "
+                         "init-keys should always be a function that accepts a "
+                         "config map and returns a config map.")
+                    {:key k}))))
+
 (defn fold-modules
   "Fold a system map of modules into an Integrant configuration. A module is a
   pure function that transforms a configuration map. The modules are traversed
   in dependency order and applied to iteratively to a blank map in order to
   build the final configuration."
   [system]
+  (doseq [[k f] system]
+    (validate-module-function k f))
   (ig/fold system (fn [m _ f] (f m)) {}))
 
 (defn- matches-name? [key profile-key]


### PR DESCRIPTION
## Problem

Currently when adding an init-key outside of `:duct.profile/base`, which is not a function (takes a config, returns a config), you get the following error.

```
Execution error (AssertionError) at integrant.core/prep (core.cljc:399).
Assert failed: (map? config)
```

This is not very helpful, because the end user will most likely assume that they made a typo in their config. I also believe new users struggle with understanding the difference between regular init-key and module init-keys. Which is why they put keys in the wrong place.

## Solution

Add validation to the `fold-modules` function, checking that each module key is an `fn`. If not, throw a custom error which is more understandable than the default.

## Notes

I'm sure the exception message / docstring can be improved on.
Also, should a private function have a docstring?