### PR TITLE
Update Medley to 1.4.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [integrant "0.7.0"]
-                 [medley "1.2.0"]]
+                 [medley "1.4.0"]]
   :plugins [[lein-codox "0.10.3"]]
   :profiles {:provided {:dependencies [[fipp "0.6.21"]
                                        [hawk "0.2.11"]


### PR DESCRIPTION
Prevents Clojure 1.11 warnings.
